### PR TITLE
Fix for "ERROR Not logged in" not caught, not "OK" status in loop

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,6 +50,7 @@ if [ $R -ne 0 ]; then
     expect \"Personal login token: \" {send \"$JOTTA_TOKEN\n\"}
     expect \"Devicename*: \" {send \"$JOTTA_DEVICE\n\"}
     expect eof
+    # TODO: Jotta may return "Found remote device that matches this machine", where a yes/no answer could be given automatically
     "
   else
     echo "ERROR: Not able to determine why Jotta cannot start:"


### PR DESCRIPTION
Proposed fix for #3 . Tested on my instance.

I also added a small TODO: Jotta may ask "Found remote device that matches this machine", if the machine already exists. I've not used "expect" before, so I do not know how to support that.